### PR TITLE
fix to examples klee-last path and .cargo folder

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,13 @@ fn analyze_rust_program(bin_name: String, opt: bool, _new: bool, verbose: bool, 
         return;
     }
 
+    if !dir.join(".cargo").exists() {
+        Command::new("mkdir")
+        .arg(".cargo")
+        .status()
+        .expect("Could not create directory .cargo");
+    }
+
     let config_file_path = dir.join(".cargo").join("config");
     fs::write(&config_file_path, format!("{}\n{}", "[build]", r#"target = "thumbv7em-none-eabihf""#)).expect("Could not write to config file");
 
@@ -137,23 +144,25 @@ fn analyze_rust_program(bin_name: String, opt: bool, _new: bool, verbose: bool, 
     }
     cargo_klee.status().expect("Failed to run cargo klee."); 
 
-    if !dir.join(".cargo").exists() {
-        Command::new("mkdir")
-        .arg(".cargo")
-        .status()
-        .expect("Could not create directory .cargo");
-    }
-
-    let path_to_label_files;
-    let path_to_ll_file;
+    let mut path_to_label_files;
+    let mut path_to_ll_file;
 
     if opt {
-        path_to_label_files = dir.join("target/thumbv7em-none-eabihf/release/deps/klee-last");
-        path_to_ll_file = dir.join("target/thumbv7em-none-eabihf/release/deps/klee-last");
+        path_to_label_files = dir.join("target/thumbv7em-none-eabihf/release");
+        path_to_ll_file = dir.join("target/thumbv7em-none-eabihf/release");
     }
     else {
-        path_to_label_files = dir.join("target/thumbv7em-none-eabihf/debug/deps/klee-last");
-        path_to_ll_file = dir.join("target/thumbv7em-none-eabihf/debug/deps/klee-last");
+        path_to_label_files = dir.join("target/thumbv7em-none-eabihf/debug");
+        path_to_ll_file = dir.join("target/thumbv7em-none-eabihf/debug");
+    }
+
+    if example {
+        path_to_label_files.push("examples/klee-last");
+        path_to_ll_file.push("examples/klee-last");
+    }
+    else {
+        path_to_label_files.push("deps/klee-last");
+        path_to_ll_file.push("deps/klee-last");
     }
     
     let mut ll_file_name = "".to_string();


### PR DESCRIPTION
When run with --rust-example bin as input, the path to output for is know /examples/klee-last instead of /deps/klee-last which is for normal rust binaries. Checking for .cargo folder was done after trying to write to it, now fixed.